### PR TITLE
Simplify repo, add craft-pr-upstream skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.swo
 .idea/
 .vscode/
-*.zip

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ cd cursor-skills
 ./scripts/install-skills.sh
 ```
 
+## Using skills in Cursor
+
+After install, skills are available in Cursor chat. The agent applies them when your request matches.
+
+**Invoke a skill:**
+- Type `@skill-name` (e.g. `@craft-pr-upstream`) to attach the skill to your message
+- Or describe what you want: "sync my branch with main", "run tests", "create PR to upstream"
+
+**Examples:**
+- `@craft-pr-upstream` — runs the full workflow: merge upstream main, resolve conflicts, push, create PR
+- `@sync-main` — merge main into your branch
+- `@format-code` — format the project
+- `@run-tests` — run the test suite
+
+Skills run automatically when the agent detects a matching intent. Use `@skill-name` when you want to force a specific skill.
+
 ## Structure
 
 Mirrors `~/.cursor`:
@@ -26,9 +42,16 @@ Mirrors `~/.cursor`:
 skills/          → ~/.cursor/skills
 skills-cursor/   → ~/.cursor/skills-cursor
 scripts/
-  install-skills.sh   # repo → ~/.cursor
-  sync-skills.sh      # ~/.cursor → repo
+  install-skills.sh   # repo → ~/.cursor (run after clone/pull)
+  sync-skills.sh      # ~/.cursor → repo (run after editing skills locally)
 ```
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `install-skills.sh` | Copy `skills/` and `skills-cursor/` from repo to `~/.cursor`. Run after clone or pull. |
+| `sync-skills.sh` | Copy `~/.cursor/skills` and `~/.cursor/skills-cursor` into repo. Run after adding or editing skills locally. |
 
 ## Install vs sync
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Install copies repo → `~/.cursor`. Sync copies `~/.cursor` → repo.
 | run-tests | Run project test suite |
 | format-code | Format with project formatter |
 | craft-pr | Create/update PR with gh CLI |
+| craft-pr-upstream | PR from fork to original repo (merge upstream main first) |
 | create-rule | Add `.cursor/rules/` |
 | create-skill | Write new skills |
 | create-subagent | Define subagents |
@@ -56,7 +57,7 @@ Install copies repo → `~/.cursor`. Sync copies `~/.cursor` → repo.
 | shell | Literal command via `/shell` |
 | update-cursor-settings | Editor settings |
 
-Skills apply when your request matches. Examples: "sync my branch with main", "run tests", "format code", "craft a PR".
+Skills apply when your request matches. Examples: "sync my branch with main", "run tests", "format code", "craft a PR", "create PR to upstream".
 
 ## Adding skills
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Sync Cursor IDE agent skills between `~/.cursor` and this repo.
 
+## Setup
+
+Clone and install:
+
+```bash
+# SSH
+git clone git@github.com:OWNER/cursor-skills.git
+cd cursor-skills
+
+# or HTTPS
+git clone https://github.com/OWNER/cursor-skills.git
+cd cursor-skills
+
+./scripts/install-skills.sh
+```
+
 ## Structure
 
 Mirrors `~/.cursor`:
@@ -10,46 +26,9 @@ Mirrors `~/.cursor`:
 skills/          → ~/.cursor/skills
 skills-cursor/   → ~/.cursor/skills-cursor
 scripts/
-  install-skills.sh
-  sync-skills.sh
+  install-skills.sh   # repo → ~/.cursor
+  sync-skills.sh      # ~/.cursor → repo
 ```
-
-## Setup
-
-```bash
-git clone <your-repo-url>
-cd <repo-name>
-./scripts/install-skills.sh
-```
-
-## New laptop (from zip)
-
-Transfer the zip to the new machine, then:
-
-```bash
-unzip cursor-commands.zip
-cd cursor-commands
-./scripts/install-skills.sh
-```
-
-To create your own repo from the content:
-
-```bash
-cd cursor-commands
-rm -rf .git
-git init
-git add .
-git commit -m "Initial: Cursor skills"
-gh repo create cursor-commands --public --source=. --remote=origin --push
-```
-
-## Package (create zip)
-
-```bash
-./scripts/package.sh
-```
-
-Creates `<repo-name>.zip` in the repo directory (excludes .git). Transfer the zip to another machine to set up there.
 
 ## Install vs sync
 
@@ -59,10 +38,6 @@ Creates `<repo-name>.zip` in the repo directory (excludes .git). Transfer the zi
 | Sync | After editing skills in ~/.cursor | `./scripts/sync-skills.sh` |
 
 Install copies repo → `~/.cursor`. Sync copies `~/.cursor` → repo.
-
-## Usage
-
-Skills apply when your request matches. Examples: "sync my branch with main", "run tests", "format code", "craft a PR".
 
 ## Skills
 
@@ -80,6 +55,8 @@ Skills apply when your request matches. Examples: "sync my branch with main", "r
 | migrate-to-skills | Convert rules/commands to skills |
 | shell | Literal command via `/shell` |
 | update-cursor-settings | Editor settings |
+
+Skills apply when your request matches. Examples: "sync my branch with main", "run tests", "format code", "craft a PR".
 
 ## Adding skills
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Create zip of repo (excludes .git)
-set -e
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-NAME="$(basename "$REPO")"
-cd "$REPO/.."
-zip -r "$REPO/${NAME}.zip" "$NAME" -x "${NAME}/.git/*" -x "${NAME}/*.zip"
-echo "Created $REPO/${NAME}.zip"

--- a/skills-cursor/craft-pr-upstream/SKILL.md
+++ b/skills-cursor/craft-pr-upstream/SKILL.md
@@ -11,7 +11,13 @@ description: >-
 
 Create a pull request from your fork to the original (upstream) repo. First merges upstream `main` into your current branch and resolves conflicts, then creates the PR.
 
+## On invoke
+
+**Start immediately.** When this skill is applied, run the first command right away. Do not summarize the workflow, ask for confirmation, or explain—use the Shell tool to run each command one by one until the PR is created or you must stop (e.g. not a fork, auth failed). Run one command, observe the result, then run the next.
+
 ## Prerequisites
+
+Run these checks first. Stop if any fail.
 
 | Check | Command | Install if missing |
 |-------|---------|--------------------|
@@ -20,9 +26,15 @@ Create a pull request from your fork to the original (upstream) repo. First merg
 | gh auth | `gh auth status` | `gh auth login` |
 | Fork | `gh repo view --json parent -q .parent` | Repo must be a fork |
 
+**First command to run:** `gh repo view --json parent -q .parent`
+
 ## Workflow
 
+Run each step in sequence. After each command, run the next. Do not batch or skip.
+
 ### 1. Ensure upstream remote
+
+Run:
 
 ```bash
 gh repo view --json parent -q .parent
@@ -39,46 +51,60 @@ git remote add upstream "https://github.com/$PARENT.git" 2>/dev/null || true
 
 ### 2. Merge upstream main and resolve conflicts
 
-1. **Save branch** – `BRANCH=$(git branch --show-current)`
-2. **Fetch upstream** – `git fetch upstream`
-3. **Merge** – `git merge upstream/main`
+Run in order:
+1. `BRANCH=$(git branch --show-current)`
+2. `git fetch upstream`
+3. `git merge upstream/main`
 4. **If conflicts** – Resolve each:
-   - List: `git status`
-   - Edit conflicted files, remove `<<<<<<<`, `=======`, `>>>>>>>` markers
-   - `git add <file>` after each resolution
-   - `git commit -m "Merge upstream/main into $BRANCH"`
+   - Run `git status` to list conflicted files
+   - Edit each file to resolve conflicts
+   - Run `git add <file>` then `git commit -m "Merge upstream/main into $BRANCH"`
 5. **If no conflicts** – Merge completes automatically (or already up to date)
 
 ### 3. Push to fork
 
-```bash
-git push origin $BRANCH
-```
+Run: `git push origin $BRANCH`
 
-### 4. Create PR to upstream
+### 4. Create PR to upstream with gh
 
-Get fork owner and upstream repo:
+Run to get values:
 
 ```bash
 FORK_OWNER=$(gh repo view --json owner -q .owner.login)
 UPSTREAM=$(gh repo view --json parent -q '.parent.owner.login + "/" + .parent.name')
 ```
 
-Check for existing PR:
+Run: `gh pr list --repo "$UPSTREAM" --head "$FORK_OWNER:$BRANCH" --base main`
 
-```bash
-gh pr list --repo "$UPSTREAM" --head "$FORK_OWNER:$BRANCH" --base main
+If a PR exists, the push in step 3 already updated it. Done.
+
+If no PR exists, run `gh pr create` to create it.
+
+First run `git diff upstream/main...HEAD --stat` to see changes. Build title and body from that output:
+
+**Title template:** One line summarizing the main change. Examples:
+- `Add X` / `Fix Y` / `Simplify Z`
+- `[TICKET-123] Add X` if user provides a ticket
+
+**Body template:** Run `git diff upstream/main...HEAD --stat` and format as:
+
+```markdown
+## Summary
+[One sentence: what this PR does]
+
+## Changes
+- [file/path]: [brief change]
+- ...
+
+## Notes
+[Optional: user context, breaking changes, follow-up]
 ```
 
-If PR exists, the push in step 3 already updated it. Done.
+Example: For `4 files changed, 106 insertions(+), 50 deletions(-)` across README, .gitignore, package.sh, craft-pr-upstream:
+- Title: `Simplify repo, add craft-pr-upstream skill`
+- Body: List each file and its change (e.g. "README: clone-only setup", "craft-pr-upstream: new skill for fork→upstream PRs")
 
-If no PR, create:
-
-```bash
-gh pr create --repo "$UPSTREAM" --base main --head "$FORK_OWNER:$BRANCH" --title "..." --body "..."
-```
-
-Build title from changes: `git diff upstream/main...HEAD --stat`. Use `[TICKET] Summary` if user provides a ticket.
+**You must run `gh pr create`** with the built title and body. Do not skip it.
 
 ## Notes
 

--- a/skills-cursor/craft-pr-upstream/SKILL.md
+++ b/skills-cursor/craft-pr-upstream/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: craft-pr-upstream
+description: >-
+  Create a PR from a fork to the original repo. Merges upstream main into
+  current branch, resolves conflicts, then opens PR. Use when the user wants
+  to contribute to upstream, open a PR to the original repo, or submit changes
+  from a fork.
+---
+
+# Craft PR to upstream
+
+Create a pull request from your fork to the original (upstream) repo. First merges upstream `main` into your current branch and resolves conflicts, then creates the PR.
+
+## Prerequisites
+
+| Check | Command | Install if missing |
+|-------|---------|--------------------|
+| Git repo | `git rev-parse --git-dir 2>/dev/null` | Must be in a git repo |
+| gh CLI | `gh --version` | `brew install gh` |
+| gh auth | `gh auth status` | `gh auth login` |
+| Fork | `gh repo view --json parent -q .parent` | Repo must be a fork |
+
+## Workflow
+
+### 1. Ensure upstream remote
+
+```bash
+gh repo view --json parent -q .parent
+```
+
+If no parent, stop—this repo is not a fork.
+
+Add upstream if missing:
+
+```bash
+PARENT=$(gh repo view --json parent -q '.parent.owner.login + "/" + .parent.name')
+git remote add upstream "https://github.com/$PARENT.git" 2>/dev/null || true
+```
+
+### 2. Merge upstream main and resolve conflicts
+
+1. **Save branch** – `BRANCH=$(git branch --show-current)`
+2. **Fetch upstream** – `git fetch upstream`
+3. **Merge** – `git merge upstream/main`
+4. **If conflicts** – Resolve each:
+   - List: `git status`
+   - Edit conflicted files, remove `<<<<<<<`, `=======`, `>>>>>>>` markers
+   - `git add <file>` after each resolution
+   - `git commit -m "Merge upstream/main into $BRANCH"`
+5. **If no conflicts** – Merge completes automatically (or already up to date)
+
+### 3. Push to fork
+
+```bash
+git push origin $BRANCH
+```
+
+### 4. Create PR to upstream
+
+Get fork owner and upstream repo:
+
+```bash
+FORK_OWNER=$(gh repo view --json owner -q .owner.login)
+UPSTREAM=$(gh repo view --json parent -q '.parent.owner.login + "/" + .parent.name')
+```
+
+Check for existing PR:
+
+```bash
+gh pr list --repo "$UPSTREAM" --head "$FORK_OWNER:$BRANCH" --base main
+```
+
+If PR exists, the push in step 3 already updated it. Done.
+
+If no PR, create:
+
+```bash
+gh pr create --repo "$UPSTREAM" --base main --head "$FORK_OWNER:$BRANCH" --title "..." --body "..."
+```
+
+Build title from changes: `git diff upstream/main...HEAD --stat`. Use `[TICKET] Summary` if user provides a ticket.
+
+## Notes
+
+- Uses merge (not rebase) to keep history clear.
+- To abort merge: `git merge --abort`
+- Run from project root.


### PR DESCRIPTION
## Changes

- Remove packaging (package.sh, *.zip from gitignore)
- Simplify README for clone-only usage (SSH/HTTPS)
- Add craft-pr-upstream skill: create PR from fork to upstream, merge upstream main first, resolve conflicts, then open PR with gh

Made with [Cursor](https://cursor.com)