### PR TITLE
Add gh-pr-upstream add/commit/push step, use configured upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ After installing, skills are available in Cursor Agent chat.
 | `/gh-pr` | Create or update a PR |
 | `/gh-push` | Add, commit, push |
 | `/gh-pull-main` | Merge main into current branch |
+| `/gh-pull-upstream` | Sync fork with upstream |
+| `/gh-pr-upstream` | Create PR from fork to upstream |
 | `/code-ship` | Format, lint, test, then commit and push |
 | `/code-format-js` | Format JS/TS with Prettier |
 | `/code-test-python` | Run pytest |

--- a/src/gh/pr-upstream/SKILL.md
+++ b/src/gh/pr-upstream/SKILL.md
@@ -16,10 +16,11 @@ Start immediately. Run commands one by one. Do not summarize.
 
 ## Workflow
 
-1. **Upstream** — `gh repo view --json parent -q .parent`. If null, stop. Add upstream if missing.
-2. **Merge** — `BRANCH=$(git branch --show-current)`, `git fetch upstream`, `git merge upstream/main`, resolve conflicts
-3. **Push** — `git push origin $BRANCH`
-4. **PR** — `UPSTREAM` = upstream remote (parse `git remote get-url upstream` → `owner/repo`). `FORK_OWNER` = origin owner (`gh repo view --json owner -q .owner.login`). Check: `gh pr list --repo $UPSTREAM --head $FORK_OWNER:$BRANCH`. If PR exists: `gh pr edit <number> --repo $UPSTREAM --title "..." --body "..."`. If none: `gh pr create --repo $UPSTREAM --base main --head $FORK_OWNER:$BRANCH --title "..." --body "..."`. Diff: `git diff upstream/main...HEAD`
+1. **Upstream** — Use configured `upstream` remote. Check: `git remote get-url upstream`. If missing: try `gh repo view --json parent -q .parent` to get upstream URL and add it (`git remote add upstream <url>`). If no upstream and parent is null, stop and ask user for upstream repo.
+2. **Add, commit, push** — `BRANCH=$(git branch --show-current)`. `git add .` (or `git add -A`). Build commit message from `git diff --cached --stat` or `git diff --stat` (one-line summary: "Add X", "Fix Y", "Refactor Z"). `git commit -m "..."` (skip if nothing to commit). `git push origin $BRANCH`. Ensures any uncommitted changes are committed and pushed before opening the PR.
+3. **Merge** — `git fetch upstream`, `git merge upstream/main`, resolve conflicts
+4. **Push** — `git push origin $BRANCH`
+5. **PR** — Parse `UPSTREAM` from `git remote get-url upstream` (e.g. `https://github.com/gardusig/cursor-skills.git` → `gardusig/cursor-skills`). `FORK_OWNER` = origin owner (`gh repo view --json owner -q .owner.login` or parse from `git remote get-url origin`). Check: `gh pr list --repo $UPSTREAM --head $FORK_OWNER:$BRANCH`. If PR exists: `gh pr edit <number> --repo $UPSTREAM --title "..." --body "..."`. If none: `gh pr create --repo $UPSTREAM --base main --head $FORK_OWNER:$BRANCH --title "..." --body "..."`. Diff: `git diff upstream/main...HEAD`
 
 ## PR description
 


### PR DESCRIPTION
## Summary

Updates gh-pr-upstream skill to run add/commit/push before opening the PR, and to use the configured upstream remote instead of relying on GitHub API parent. Adds slash command examples to README.

## Modified (2)

- `README.md` — Add gh-pull-upstream and gh-pr-upstream to slash command examples table
- `src/gh/pr-upstream/SKILL.md` — Add add/commit/push step; use configured upstream remote; parse FORK_OWNER from origin URL as fallback